### PR TITLE
increase readability and streamline instructions

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,14 +1,14 @@
 # Welcome
 
 Welcome to the ReactGenie Developer Study!
-Today, you will be building a Timer App using the ReactGenie framework.
+Today, you will be building a multimodal Timer App using the ReactGenie framework.
 We've prepared detailed instructions and documentation to assist you along the way.
 
 We've put together a tutorial to help you learn ReactGenie before you build a timer app. 
 In the tutorial, we'll show you how to build a simple Counter app. You can use this as a reference
 to build a timer app.
 
-We've also provided documentation for ReactGenie that you can reference for specific features 
+We've also provided documentation for ReactGenie that you can consult for specific features
 of ReactGenie.
 
 Please move on to the Instructions section when you're ready to start the study!

--- a/pages/instructions/counter.mdx
+++ b/pages/instructions/counter.mdx
@@ -2,22 +2,20 @@
 This tutorial will demonstrate how to use ReactGenie to build a simple Counter app.
 
 ### 2.1 ReactGenie Overview
-We'll start with a brief introduction to the ReactGenie framework to help you understand how to build applications.
+We'll start with a brief introduction to the ReactGenie framework to help you understand how to build multimodal applications using ReactGenie.
 
 Each multimodal app built with ReactGenie consists of three parts:
 
 1. **State Code**: This is used to control and manage the state, such as data and executing functions. 
 It is written in the <font color="red">`genie`</font> folder.
 
-2. **UI Code**: This is used to display information and enable user interactions with React and CSS. 
+2. **Link UI Code to State**: This is used to display the state data and allow users to interact with the data via the UI.
 It is written in the <font color="red">`src`</font> folder.
 
-3. **Combine**: This involves linking the State and UI code by integrating state executing functions with UI user interactions, 
-as well as accessing state data via stored variables.
-in <font color="red">`App.tsx`</font> and <font color="red">`store.ts`</font>.
+3. **Link State Code to UI**: This involves linking the State to UI so ReactGenie knows using which UI to render which type of results. You will need to modify <font color="red">`App.tsx`</font> and <font color="red">`store.ts`</font>.
 
-For example, the state code for the upcoming Counter includes Counter class for counter state management,
-while the UI code for displaying the counter input form and countdown interface for added counters.
+For example, in the upcoming Counter app tutorial, the state code includes the Counter class (`Counter.ts`) for counter state management,
+and the UI code includes views of the counter input form and the interface for added counters (e.g., `EditCounterView.tsx`).
 
  ```bash {3,6,7,8,9}
 - genie
@@ -51,7 +49,7 @@ npm install
 npx expo start --web 
 ```
 
-You should see the following content in the openend browser:
+You should see the following content in the browser:
 
 ```
 Welcome to ReactGenie Developer Study !
@@ -61,21 +59,18 @@ Note that the ReactGenie framework provides a microphone button on the bottom ri
 to utilize the React Genie voice interface when they would like to. Users can also continue to use the graphical user interface (GUI) as 
 they please.
 
-### 2.3 Create state classes
+### 2.3 State Code
+
+#### 2.3.1 Create state classes
 
 ReactGenie provides you with two inbuilt classes that you can extend from for your state classes.
 1. **DataClass**: A DataClass is the basic unit for data management, and an instance of a DataClass can be viewed as a record in a database. 
-The property in a DataClass can be a number, string, boolean, list, DataClass, or a HelperClass. Read more in the docs.
-2. **HelperClass**: The HelperClass stores and manages complex data types for a DataClass. These are serialized and deserialized. Read more in the docs.
+The property in a DataClass can be a number, string, boolean, list, DataClass, or a HelperClass. Read more in the [docs](https://react-genie-developer-study.vercel.app/geniedoc/decorators#dataclass).
+2. **HelperClass**: The HelperClass stores and manages complex data types. They will be used to define complex properties in a Dataclass, so that they can be serialized and deserialized. Read more in the [docs](https://react-genie-developer-study.vercel.app/geniedoc/decorators#helperclass).
 
-When implementing React Genie state, you will need to create a class using DataClass. You'll only need a helper class, if you need complex data storage.
+Note: **You don't need to create any HelperClass today.** However, you will need to use predefined HelperClass (i.e., `DateTime` and `TimeDelta`) for creating complex properties in your DataClass.
 
-ReactGenie will then handle the creation, management, update, and storage of all state classes (<font color="red">`DataClass`</font>es). It can only 
-support primitive types (e.g., <font color="red">`string`</font>, <font color="red">`int`</font>, <font color="red">`float`</font>, 
-<font color="red">`boolean`</font>), arrays of primitive types, compound types (e.g., <font color="red">`DateTime`</font> 
-and <font color="red">`TimeDelta`</font>), and arrays of compound types.
-
-Let's get started with implementing a Counter class to store and manage our Counters!
+Let's get started with implementing a Counter Dataclass to store and manage our Counters!
 
 Initialize the file <font color="red">`Counter.ts`</font> under the <font color="red">`genie`</font> folder:
 ```bash
@@ -83,10 +78,12 @@ Initialize the file <font color="red">`Counter.ts`</font> under the <font color=
     -Counter.ts
 ```
 
-```typescript filename="Counter.ts" {4}
+To create a DataClass, you need to define all the properties of the DataClass in primitive types (e.g., <font color="red">`string`</font>, <font color="red">`int`</font>,
+                                                                                                  <font color="red">`boolean`</font>), arrays of primitive types, compound types using HelperClass, or arrays of compount types.
+
+```typescript filename="Counter.ts" {4, 5, 6, 7}
 import { GenieClass, DataClass, int } from "reactgenie-lib";
 
-@GenieClass("A counter example")
 export class Counter extends DataClass{
     public name: string;
     public type: string;
@@ -95,21 +92,12 @@ export class Counter extends DataClass{
 }
 ```
 
-Please review our documentation for decorators. All classes, functions, and properties need to be wrapped with ReactGenie decorators 
-if they need to be accessed by ReactGenie. They need to include a description that explains its purpose, so ReactGenie is able to access it 
-for relevant voice commands/actions.
+Now we're introducing a key concept in ReactGenie, the ReactGenie decorators.
+ReactGenie can transform users' natural language queries to function calls.
+To achieve this, you need to add a ReactGenie decorator for the classes, functions, and properties that you want the users to be able to access with multimodal interactions (voice + touch).
+In the decorator, you can optionally specify a string to describe the purpose of the class, function, or property.
 
-_A state class in ReactGenie has to extend <font color="red">`DataClass`</font> and 
-be annotated with <font color="red">`@GenieClass("{description of the class}")`</font> to 
-ReactGenie better understand the role of the class._
-
-We'll need four class properties type, name, count, and created for our counter.
-
-There may be many properties in a class, and we only want to expose some of them to ReactGenie for user to interact 
-with them multimodally. For the properties you want to expose to ReactGenie for multimodal interactions, wrap them with 
- <font color="red">`@GenieProperty("{description of the property}")`</font> decorator.
-
-```typescript filename="Counter.ts" {5,7,9,11}
+```typescript filename="Counter.ts" {3, 5, 7, 9, 11}
 import { GenieClass, DataClass, GenieProperty, int } from "reactgenie-lib";
 
 @GenieClass("A counter example")
@@ -118,16 +106,16 @@ export class Counter extends DataClass{
     public name: string;
     @GenieProperty("The type of objects (vegetable, fruit, ...)")
     public type: string;
-    @GenieProperty()
+    @GenieProperty() // You can omit the description
     public count: int;
-    @GenieProperty()
+    @GenieProperty() // You can omit the description
     public created: boolean;
 }
 ```
 
-This class is still missing one important piece. Each <font color="red">`DataClass`</font> requires a key to 
+This class is still missing one important piece. Each <font color="red">`DataClass`</font> requires a key to
 help ReactGenie manage the classes. The key has to be unique for each instance of the class.
-In ReactGenie, this is done through wrapping the key property with <font color="red">`@GenieKey`</font> decorator.
+In ReactGenie, this is done through annotating the key property with a <font color="red">`@GenieKey`</font> decorator.
 Let's add this to our class:
 
 
@@ -143,23 +131,23 @@ export class Counter extends DataClass{
     public name: string;
     @GenieProperty("The type of objects (vegetable, fruit, ...)")
     public type: string;
-    @GenieProperty()
+    @GenieProperty() // You can omit the description
     public count: int;
-    @GenieProperty()
+    @GenieProperty() // You can omit the description
     public created: boolean;
 }
 ```
 
-To recap, a state class (<font color="red">`DataClass`</font>) in ReactGenie requires the following decorators:
+To recap, a state class (<font color="red">`DataClass`</font>) in ReactGenie requires three types of decorators:
 * <font color="red">`@GenieClass("{description of the class}")`</font> that extends <font color="red">`DataClass`</font>
 * <font color="red">`@GenieProperty("{description of the property}")`</font>: properties that you want to expose to ReactGenie
 * <font color="red">`@GenieKey`</font>: a unique key for each instance of the class
 
-### 2.4 State class management
+#### 2.3.2 State class management
 
-Now that we've defined our properties, we need to initialize these properties using a constructor. This is required for the properties.
+Now that we've defined our properties, we need to initialize these properties using a constructor. This is required for all the properties.
 
-```typescript filename="Counter.ts" {17}
+```typescript filename="Counter.ts" {17, 18, 19, 20, 21, 22, 23, 24}
 import { GenieClass, DataClass, GenieKey, GenieProperty, int } from "reactgenie-lib";
 
 @GenieClass("A counter example")
@@ -167,9 +155,9 @@ export class Counter extends DataClass{
     @GenieKey
     public id:string;
 
-    @GenieProperty()
+    @GenieProperty("The name of object that you want to count")
     public name: string;
-    @GenieProperty()
+    @GenieProperty("The type of objects (vegetable, fruit, ...)")
     public type: string;
     @GenieProperty()
     public count: int;
@@ -187,30 +175,6 @@ export class Counter extends DataClass{
 }
 ```
 
-In the constructor, we need to destructure the function properties and declare types for each. In typescript, we often create a 
-separate interface for readability as such: 
-```typescript
-interface CounterProps {
-    id: string,
-    name: string, 
-    type: string, 
-    count?: int, 
-    created:boolean
-}
-
-constructor({id, name, type, count = 0, created}: CounterProps) {...}
-```
-
-This is the same concept, just implemented inline instead. The `?` is used to declare optional properties for the class. 
-Destructuring allows us to utitlize optional properties:
-```typescript
-// without Destructuring
-function example(a: int, b: int){}
-// with Destructuring
-function example({a, b}: {a: int, b: int}){}
-// with Destructuring and default value
-function example({a, b = 0}: {a: int, b?: int}){}
-```
 
 **NOTE**
 You should AVOID directly calling the constructor like below:
@@ -226,7 +190,7 @@ Instead, ReactGenie provides the three static functions below to help you manage
 <font color="red">`All()`</font> allows you to get an array of all instances of a specific class.
 <font color="red">`DeleteObject()`</font> allows you to delete a object through its <font color="red">`GenieKey`</font>.
 
-Please use these for relevant functionalities so ReactGenie is able to track it.For example:
+Please use these functions to create and access the objects so that ReactGenie can track the objects. For example:
 ```typescript filename="Counter.ts"
 const appleCounter = Counter.CreateObject({id: "1", name: "apple", type: "fruit", count: 0, created:true})
 const getAppleCounter = Counter.GetObject({id: "1"}) // getAppleCounter === appleCounter
@@ -236,10 +200,10 @@ const allCountersAfterDelete = Counter.All() // allCountersAfterDelete === []
 ```
 
 <font color="red">Note that only `All()` is automatically exposed to multimodal interactions.</font>
-If you want to allow user to create a counter while using the app, you need to create a function for it.
+If you want to allow users to access other functions to handle the objects, you need to create a function and add a ReactGenie decorator for it.
 
 For example, if we want to allow users to say "Create an apple counter", we need to create a function like:
-```typescript filename="Counter.ts" {18}
+```typescript filename="Counter.ts" {8, 9, 10, 11, 12, 13}
 import { GenieClass, DataClass, GenieKey, GenieProperty, GenieFunction, int } from "reactgenie-lib";
 
 @GenieClass("A counter example")
@@ -257,13 +221,13 @@ export class Counter extends DataClass{
 ```
 
 
-### 2.5 Setup placeholder objects
+#### 2.3.3 Setup placeholder objects
 ReactGenie provides you with class initialization settings, where you can set static variables for the class or create placeholder objects.
 The setup() function is a static function of the GenieClass. You can override the setup function for initial program
  setup. ReactGenie will automatically call the function to complete the initialization. 
 
 > For counter, we can set up three counters in the initialization.
-```typescript filename="Counter.ts" {4}
+```typescript filename="Counter.ts" {4, 5, 6, 7, 8}
 @GenieClass("A counter example")
 export class Counter extends DataClass{
     //...
@@ -274,10 +238,10 @@ export class Counter extends DataClass{
     }
 }
 ```
-### 2.7 Add you own functions
+#### 2.3.4 Add you own functions
 Next, you can create more functionalities for your class.
-we can creat increase, decrease and delete functions.
-```typescript filename="Counter.ts" {6,11,16}
+For example, you can create functions to increment, decrement, and delete the counter. Don't forget to add ReactGenie decorators as these functions should be accessible to users via multimodal interactions.
+```typescript filename="Counter.ts" {5, 6, 7, 8, 10, 11, 12, 13, 15, 16, 17, 18}
 @GenieClass("A counter example")
 export class Counter extends DataClass{
     //...
@@ -299,12 +263,8 @@ export class Counter extends DataClass{
 }
 ```
 
-Note that similar to <font color="red">`GenieProperty`</font>, <font color="red">`GenieFunction`</font> is used to expose functions to ReactGenie that users can increment and decrement the counter via multimodal interactions.
-
-The parameters of <font color="red">`GenieFunction`</font> should also be destructured and the return value should be explicit, but it can be explicit <font color="red">`void`</font>.
-
-Of course, you can also create functions to set names, types, etc., to support more possible features.
-Here we get a example state code for Counter:
+Of course, you can also create functions to set names, types, etc., to support more features.
+Here we get an example state code for Counter:
 <details>
 <summary>Counter.ts</summary>
 ```typescript
@@ -315,9 +275,9 @@ export class Counter extends DataClass{
     @GenieKey
     public id: string;
 
-    @GenieProperty()
+    @GenieProperty("The name of object that you want to count")
     public name: string;
-    @GenieProperty()
+    @GenieProperty("The type of objects (vegetable, fruit, ...)")
     public type: string;
     @GenieProperty()
     public count: int;
@@ -365,12 +325,11 @@ export class Counter extends DataClass{
 ```
 </details>
 
+### 2.4 Link UI Code to State
 
-### 2.6 Write UI code
-Now we need to determine what to display in a Counter app 
-and what kind of graphical UI interface to construct. 
-The Counter app will comprise two pages, 
-one dedicated to editing a specific Counter and the other designed to display the list of Counters.
+#### 2.4.1 Write UI code and bind state with it
+Now we need to determine what to display in a Counter app and what kind of graphical UI to construct.
+The Counter app will comprise two pages, one dedicated to editing a specific Counter and the other designed to display the list of Counters.
 
 ```bash {3,6,7,10}
 - src
@@ -386,22 +345,15 @@ one dedicated to editing a specific Counter and the other designed to display th
 ```
 
 Like React, you need to implement the UI interface in the form of a component. 
-In addition, you need to bind this component with a specific data type so that 
-when ReactGenie obtains the execution results, it will use the page you specified for display.
+In addition, you need to bind this component with a specific data type so that when ReactGenie obtains the execution results, it will use the page you specified for display.
 
 So the code is divided into two parts.
-The first part involves the specific implementation of the UI, 
-while the second part deals with binding the UI with data types.
+The first part involves the specific implementation of the UI, and the second part deals with binding the UI with data types.
 
-We can pass the GenieKey to UI to get Counter object. 
-With basic UI code, we need to use <font color="red">`useGenieSelector()`</font> to obtain ReactGenie object.
+To bind the state data with the UI, we need to use <font color="red">`useGenieSelector()`</font> to obtain ReactGenie object.
+We can obtain the ReactGenie object data based on the parameters passed in by the component (e.g., `props: {id:string}`) and modify the data according to user operations.
 
-<font color="red">`useGenieSelector()`</font>: wrapper function used to access ReactGenie data
-
-We can obtain ReactGenie object data based on the parameters passed in by the component, 
-and modify the data according to user operations.
-
-Let's start by writing the implementation of UI. 
+Below are files that demonstrate both the the implementation of UI and examples of binding the UI with data types using `useGenieSelector`.
 Don't forget to import <font color="red">`React`</font> in the <font color="red">`.tsx`</font> file.
 
 The edit page is used to modify the counter or create a new counter.
@@ -467,7 +419,7 @@ Counter item shows the information of the counter.
 
 <details>
 <summary>CounterItemView.tsx</summary>
-```typescript filename="CounterItemView.tsx" {7,8,13,16,17}
+```typescript filename="CounterItemView.tsx" {7,8,13,16,17,18}
 import React from "react";
 import {Pressable} from "react-native";
 import {useGenieSelector} from "reactgenie-lib";
@@ -520,7 +472,7 @@ export const CounterListView = CounterListViewImpl;//TODO: need to be linked
 </details>
 
 
-Finally, we need to creat a MainView page.
+Finally, we need to create a MainView page.
 <details>
 <summary>MainView.tsx</summary>
 ```typescript filename="MainView.tsx" {9,17}
@@ -557,7 +509,7 @@ Don't store data in the UI, please use state code to store data and call the dat
 in the UI. </font>
 
 
-### 2.7 Page Management with AppNavigator
+#### 2.4.2 Page Management with AppNavigator
 We need to include the main UI framework in <font color="red">`App.tsx`</font>. 
 ReactGenie UI must be implemented in <font color="red">`ModalityProvider`</font>.
 
@@ -565,10 +517,10 @@ Here we will use <font color="red">`AppNavigator`</font> to handle the switch be
 <font color="red">`AppNavigator`</font> is just like a stack for pages, you can display the new page with <font color="red">`push()`</font>
  and back to the previous page with <font color="red">`pop()`</font>. 
 
-We can regist two pages in <font color="red">`App.tsx`</font> with <font color="red">`AppNavigator`</font>
+We can register two pages in <font color="red">`App.tsx`</font> with <font color="red">`AppNavigator`</font>
 <details>
 <summary>App.tsx</summary>
-```typescript filename="App.tsx" {16,23,31,35,36,53}
+```typescript filename="App.tsx" {16,23,31,35,36,51}
 import React from "react";
 import {Provider} from "react-redux";
 import {NativeStackScreenProps} from "@react-navigation/native-stack";
@@ -720,13 +672,13 @@ export const EditCounterView = EditCounterViewImpl; //TODO: need to be linked
 Now we can run `npx expo start --web` to test the UI and 
 click the button to check whether we can get a new page. 
 
-### 2.8 Link UI to State Code
+### 2.5 Link State Code to UI
 
 After we complete the UI code and state code, we need to bind them together with **GenieClassInterface()** and 
 set up the initialization of ReactGenie. 
 
-Then we need to annotate the data type used for display in the corresponding UI,
- so that when ReactGenie gets the executed results, it will choose the UI to display according to the result type.
+We need to annotate the data type used for display in the corresponding UI,
+ so that when ReactGenie gets the executed results, it will choose the proper UI based on the result type to display the results.
 
 The parameters for GenieClassInterface are: <font color="red">DataType</font>(string), <font color="red">displayTitle</font> (string | function return string), 
  <font color="red">Priority</font>(number | function return string, large means high priority).
@@ -775,19 +727,19 @@ If we want to manually complete the initialization, call our initialization func
 export const reactGenieStore = initReactGenie();
 ```
 
-### 2.8 Add Examples and Test
-Finally, we need to add usage instances for your program to help LLM correctly generate 
-executable results. We can provide examples of relevant function usage in each class.
+### 2.6 Add Examples and Test
+Finally, we need to add usage instances for your program to help ReactGenie correctly generate
+executable results using LLM. We need to provide examples of relevant function usage in each class.
 
-Exampels is a static list in GenieClass. <font color="red">The parameters in the cases are different from the functions, they should not be Destructuring</font>
+Below is an example of a static list in GenieClass. <font color="red">The parameters in the cases are different from the functions, they should not be Destructuring (i.e., the curly brackets should not be used). </font>
 ```typescript
 //Right
-"Couter.CreateCounter(type:\"fruit\")" 
+"Counter.CreateCounter(type:\"fruit\")"
 //Wrong
-//"Couter.CreateCounter({type:\"fruit\"})"
+//"Counter.CreateCounter({type:\"fruit\"})"
 ```
 
-To help uesr achieve more interactions, ReactGenie supports some filtering operations on arrays.
+To help users achieve more interactions, ReactGenie supports some filtering operations on arrays.
 
 **matching(field, value), equal(field, value)**
 

--- a/pages/instructions/timer.mdx
+++ b/pages/instructions/timer.mdx
@@ -33,8 +33,8 @@ Install dependencies using `npm install`.
 You can run the app using `npx expo start --web`.
 
 ### 3.3 Preset Class
-ReactGenie has preset structure <font color='red'>**DateTime**</font>. You can use it to help you build the Timer. 
-Check out the **Preset Class** section to get more information about them.
+ReactGenie has provided preset HelperClass <font color='red'>**DateTime**</font> and <font color='red'>**TimeDelta**</font>. You can use them to help you build the Timer.
+Check out the [**Preset Class**](https://react-genie-developer-study.vercel.app/geniedoc/preset) section to get more information about them.
 
 Here we list some function you might need.
 ```typescript filename="TimeDelta"
@@ -78,11 +78,11 @@ We've broken the boilerplate code into 3 parts.
 It is written in the <font color="red">`genie`</font> folder. We've set up a file `genie/Timer.ts` for you. Please implement 
 your Timer app state code there.
 
-2. **UI Code**: This is used to display information and interact with the user. It is written in the 
+2. **Link UI Code to State**: This is used to display the state data and allow users to interact with the data via the UI. It is written in the
 <font color="red">`src`</font> folder. We've already provided all of the UI code for you, but you will need to integrate 
-the store data values and methods into the components.
+the state data values and methods to interact with the states into the components.
 
-3. **Combine**: This involves linking the State and UI code in <font color="red">`App.tsx`</font> and <font color="red">`store.ts`</font>.
+3. **Link State Code to UI**: This involves linking the State to UI so ReactGenie knows using which UI to render which type of results. You will need to modify <font color="red">`App.tsx`</font> and <font color="red">`store.ts`</font>.
 
 ### 3.5 Good luck!
 


### PR DESCRIPTION
I made some changes to the study website to increase the readability of the text, increase the consistency in the terms and structures across different pages, and simplify some instructions.

Specifically, I renamed the three parts of the task to "State Code", "Link UI code to State" and "Link State code to UI". Hopefully it helps clarify the difference between the two "binding/linking" between UI and State mentioned in 2.4.1 and 2.5

I then applied the same structure to the Timer task as well to increase the consistency.

For text that mentions "please refer to xxx in the ReactGenie doc", I tried my best to embed a link to the corresponding section of the doc. Please try to add more pointers to help the participants navigate the doc.

There are a few places that weren't very clear to me so I had to speculate a little. Feel free to add comments or propose changes for things that are inaccurate or unclear.